### PR TITLE
Updates to reflect recent changes

### DIFF
--- a/beginner/building-first-pipeline/matlab/computed-table.rst
+++ b/beginner/building-first-pipeline/matlab/computed-table.rst
@@ -385,10 +385,12 @@ above the threshold. This returns an array of 0's and 1's where 1's corresponds 
 where neuron's activity was above the threshold, storing this as ``above_thrs``.
 
 We then find out all the timebins at which the activity goes from 0 to 1, signifying times
-at which the neuron's activity **raised above the threshold**, storing this into ``rising``! 
-We then adjust this array so that it has the same length as the original ``activity``,
-and store the result as our detected ``spikes``! We store the computed ``spikes`` and ``count`` by inserting into this (``Spieks``)
-table!!
+at which the neuron's activity **raised above the threshold**, storing this into ``rising``!
+MATLAB's built-in `diff() <https://www.mathworks.com/help/matlab/ref/diff.html>`_ function
+gives us the difference between adjacent values, which is an array one-item shorter that the input.
+We adjust this array so that it has the same length as the original ``activity``,
+and store the result as our detected ``spikes``! We store the computed ``spikes`` and ``count`` 
+by inserting into this (``Spikes``) table!!
 
 .. code-block:: matlab
   :emphasize-lines: 10-13

--- a/beginner/building-first-pipeline/matlab/computed-table.rst
+++ b/beginner/building-first-pipeline/matlab/computed-table.rst
@@ -602,11 +602,12 @@ inspecting the ``Spikes`` table:
   15 tuples (0.0409 s)
 
 Even better, we can see the values of ``SpikeDetectionParam`` together by :ref:`joining 
-<matlab-join>` the two tables together:
+<matlab-join>` the two tables together. We can also add the same filtering we previously
+learned, by specifying a date:
 
 .. code-block:: matlab
 
-  >> spikes * sdp
+  >> spikes * sdp & 'session_date = "2017-05-15"'
 
   ans = 
 
@@ -617,21 +618,12 @@ Even better, we can see the values of ``SpikeDetectionParam`` together by :ref:`
     ________    ____________    ______    _____    _________    ________
 
       0         '2017-05-15'    0          27      0.9          '=BLOB='
-      0         '2017-05-19'    0          21      0.9          '=BLOB='
-      5         '2017-01-05'    0          14      0.9          '=BLOB='
-    100         '2017-05-25'    0          35      0.9          '=BLOB='
-    100         '2017-06-01'    0          15      0.9          '=BLOB='
       0         '2017-05-15'    1         128      0.1          '=BLOB='
-      0         '2017-05-19'    1         135      0.1          '=BLOB='
-      5         '2017-01-05'    1         132      0.1          '=BLOB='
-    100         '2017-05-25'    1         142      0.1          '=BLOB='
-    100         '2017-06-01'    1         151      0.1          '=BLOB='
-      0         '2017-05-15'    2          13      1.3          '=BLOB='
-      0         '2017-05-19'    2           5      1.3          '=BLOB='
-
+      0         '2017-05-15'    1          13      1.3          '=BLOB='
+    
           ...
 
-  15 tuples (0.0533 s)
+  3 tuples (0.00604 s)
 
   
 

--- a/beginner/building-first-pipeline/python/computed-table.rst
+++ b/beginner/building-first-pipeline/python/computed-table.rst
@@ -557,22 +557,18 @@ inspecting the ``Spikes`` table:
    (15 tuples)
 
 Even better, we can see the values of ``SpikeDetectionParam`` together by :ref:`joining 
-<python-join>` the two tables together:
+<python-join>` the two tables together. We can also add the same filtering we previously
+learned, by specifying a date:
 
 .. code-block:: python
 
-  >> spikes * sdp
+  >> spikes * sdp & 'session_date = "2017-05-15"'
   *mouse_id    *session_date  *sdp_id    count     threshold     spikes
   +----------+ +------------+ +--------+ +-------+ +-----------+ +--------+
   0            2017-05-15     0          27        0.9           <BLOB>
-  0            2017-05-19     0          21        0.9           <BLOB>
-  5            2017-01-05     0          14        0.9           <BLOB>
-  100          2017-05-25     0          35        0.9           <BLOB>
-  100          2017-06-01     0          15        0.9           <BLOB>
   0            2017-05-15     1          128       0.1           <BLOB>
-  0            2017-05-19     1          135       0.1           <BLOB>
-     ...
-   (15 tuples)
+  0            2017-05-15     2          13        1.3           <BLOB>
+   (3 tuples)
 
 .. note:: python
   By default preview of the table will show only the first 7 entries in the table. If you

--- a/beginner/building-first-pipeline/python/computed-table.rst
+++ b/beginner/building-first-pipeline/python/computed-table.rst
@@ -354,10 +354,12 @@ above the threshold. This returns an array of 0's and 1's where 1's corresponds 
 where neuron's activity was above the threshold, storing this as ``above_thrs``.
 
 We then find out all the timebins at which the activity goes from 0 to 1, signifying times
-at which the neuron's activity **raised above the threshold**, storing this into ``rising``! 
+at which the neuron's activity **raised above the threshold**, storing this into ``rising``!
+Numpy's `diff() <https://numpy.org/doc/stable/reference/generated/numpy.diff.html>`_ helps by
+taking the difference between each value and subsequent value.
 We then adjust this array so that it has the same length as the original ``activity``,
-and store the result as our detected ``spikes``!
-
+and store the result as our detected ``spikes``, by prepending a 0 with 
+`hstack() <https://numpy.org/doc/stable/reference/generated/numpy.hstack.html>`_.
 
 .. code-block:: python
   :emphasize-lines: 12

--- a/setting-up/datajoint-matlab.rst
+++ b/setting-up/datajoint-matlab.rst
@@ -44,7 +44,7 @@ Whichever option you have selected from :doc:`get-database`, you will need three
 to the database server: the database address, username and password.
 
 .. note::
-  If you have signed up for a tutorial database at `DataJoint.io <https://datajoint.io>`_ you should have received
+  If you have signed up for a tutorial database at `Accounts.DataJoint.io <https://accounts.datajoint.io/login>`_ you should have received
   an email with instructions on how to connect to the database, including the host address, username, and your
   temporary password.
 

--- a/setting-up/datajoint-python.rst
+++ b/setting-up/datajoint-python.rst
@@ -33,7 +33,16 @@ by just running the following in the terminal:
 
 
 and that's it! This should trigger the installation of the latest DataJoint and all of its dependencies. 
-Depending on how your Python environment is configured, you may have to prefix `sudo` to the above command.
+Depending on how your Python environment is configured, you want to install within a 
+`virtual environment <https://virtualenv.pypa.io/en/latest/user_guide.html>`_, installing for the user. Optionally:
+
+.. code-block:: bash
+
+    $ pip install virtualenv
+    $ virtualenv venv/ && source venv/bin/activate
+    $ (venv) pip3 install --user datajoint
+    $ # Later:
+    $ deactivate # to exit from venv
 
 Verify that the package was properly installed by starting a Python 3 console, and try importing the 
 `datajoint` package:

--- a/setting-up/datajoint-python.rst
+++ b/setting-up/datajoint-python.rst
@@ -33,7 +33,7 @@ by just running the following in the terminal:
 
 
 and that's it! This should trigger the installation of the latest DataJoint and all of its dependencies. 
-Depending on how your Python environment is configured, you want to install within a 
+Depending on how your Python environment is configured, you may want to install within a 
 `virtual environment <https://virtualenv.pypa.io/en/latest/user_guide.html>`_, installing for the user. Optionally:
 
 .. code-block:: bash

--- a/setting-up/datajoint-python.rst
+++ b/setting-up/datajoint-python.rst
@@ -38,6 +38,10 @@ Depending on how your Python environment is configured, you may have to prefix `
 Verify that the package was properly installed by starting a Python 3 console, and try importing the 
 `datajoint` package:
 
+.. code-block:: bash
+
+    $ python3
+    
 .. code-block:: python
 
   >>> import datajoint as dj
@@ -122,7 +126,7 @@ and that's it!
 
 .. note::
   If you have signed up to and are connected to the tutorial database on 
-  `DataJoint.io <https://datajoint.io>`_, it is strongly recommeded that you 
+  `Accounts.DataJoint.io <https://accounts.datajoint.io/login>`_, it is strongly recommeded that you 
   change your password from the temporary password that was sent to you in 
   the email!
 

--- a/setting-up/datajoint-python.rst
+++ b/setting-up/datajoint-python.rst
@@ -40,7 +40,7 @@ Depending on how your Python environment is configured, you may want to install 
 
     $ pip install virtualenv
     $ virtualenv venv/ && source venv/bin/activate
-    $ (venv) pip3 install --user datajoint
+    $ (venv) pip3 install datajoint
     $ # Later:
     $ deactivate # to exit from venv
 

--- a/setting-up/get-database.rst
+++ b/setting-up/get-database.rst
@@ -11,7 +11,7 @@ Connect to DataJoint.io_ (Recommended)
 .. _DataJoint.io: https://datajoint.io
 
 If you want to get started trying out DataJoint as quickly as possible with minimal setup, sign up for 
-`DataJoint.io <https://datajoint.io>`_ account to gain access to the free tutorial database server in addition 
+`DataJoint.io <https://accounts.datajoint.io/login>`_ account to gain access to the free tutorial database server in addition 
 to ready-to-play interactive Python playground environment based on Jupyter. 
 
 


### PR DESCRIPTION
Related to 'Accessibility' discussion:
- Changed references from DataJoint.io -> Accounts.DataJoint.io
- Added more explicit codeblocks
- Assumed entry level users when describing `make()` function, added references to other functions used
- Removed `sudo pip` suggestion per issue [#217](datajoint/datajoint-docs#217), changed to `virtualenv`

Existing site is behind main branch, see `make` vs `make_tuples` [site](https://tutorials.datajoint.io/beginner/building-first-pipeline/python/importing-data.html) vs. [main git branch](https://github.com/datajoint/datajoint-tutorial/blob/master/beginner/building-first-pipeline/python/importing-data.rst). Consider re-generating site after merging current PR(s)